### PR TITLE
fix get_hooks_from_the_first_device

### DIFF
--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -1325,7 +1325,7 @@ class Estimator(object):
         # TODO(yuefengz): add a test for unwrapping per_device_hooks.
         def get_hooks_from_the_first_device(per_device_hooks):
           return [
-              self._distribution.unwrap(per_device_hook)[0]
+              self._train_distribution.unwrap(per_device_hook)[0]
               for per_device_hook in per_device_hooks
           ]
 


### PR DESCRIPTION
Here i create a cifar10_ResNet Model and run the model in a distribution mode and find the error "the Estimator has no attribute named _distribution" and i can't get the get_hooks, so i modify _distribution to _train_distribution. The model is attached in the file for testing.

Type this command:
python cifar10_main.py --data-dir=./cifar-10-data --job-dir=./model_dir/ --num-gpus=0 --train-steps=1000
[ResNet_Cifar10.zip](https://github.com/tensorflow/estimator/files/2495319/ResNet_Cifar10.zip)
