### PR TITLE
[Features] Support `input_context` arguments for `input_fn` in DistributionStrategy

### DIFF
--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -1078,7 +1078,7 @@ class EstimatorV2(object):
       kwargs['config'] = self.config
     if input_context and 'input_context' in input_fn_args:
       logging.info('`input_context` has been detected in `input_fn`.'
-                   'Placement willi be taken over by DistributionStrategy.')
+                   'Placement will be taken over by DistributionStrategy.')
       kwargs['input_context'] = input_context
       return input_fn(**kwargs)
     else:

--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -1077,13 +1077,11 @@ class EstimatorV2(object):
     if 'config' in input_fn_args:
       kwargs['config'] = self.config
     if input_context and 'input_context' in input_fn_args:
-      logging.info('`input_context` has been detected in `input_fn`.'
-                   'Placement will be taken over by DistributionStrategy.')
+      logging.info('The `input_fn` accepts an `input_context` which will '
+                   'be given by DistributionStrategy')
       kwargs['input_context'] = input_context
+    with ops.device('/cpu:0'):
       return input_fn(**kwargs)
-    else:
-      with ops.device('/cpu:0'):
-        return input_fn(**kwargs)
 
   def _call_model_fn(self, features, labels, mode, config):
     """Calls model function.


### PR DESCRIPTION
The InputContext in DistributionStrategy is very useful for estimator training especially for reading data shards according to input_pipeline_id in multiple nodes. This PR does some works in compatibility for mode,params and config arguments in input_fn.
Please take a look. Thanks very much. @yuefengz