### PR TITLE
estimator/BestExporter: don't load current metric from disk initially

### DIFF
--- a/tensorflow_estimator/python/estimator/exporter.py
+++ b/tensorflow_estimator/python/estimator/exporter.py
@@ -288,7 +288,8 @@ class BestExporter(Exporter):
              is_the_final_export):
     export_result = None
 
-    if self._model_dir != estimator.model_dir and self._event_file_pattern:
+    if self._model_dir is not None and self._model_dir != estimator.model_dir \
+        and self._event_file_pattern:
       # Loads best metric from event files.
       tf_logging.info('Loading best metric from event files.')
 


### PR DESCRIPTION
The first time export() is called, model_dir is None, and we follow the path of reloading the best metric from disk. In the common case though, the model_dir is the same as the path where we load from, and the best metric we load is exactly the current metric we're asking to evaluate.
All in all, this results in BestExporter never performing an export the first time export() is called, and never exporting at all if the metric does not improve after the first export() call.

This is mostly relevant in testing code: the model might not be trained for any significant amount of time (usually, only one gradient update), but it's still desirable to export it, so that loading/serving paths can be tested too.