### PR TITLE
Allow multiple evaluator tasks for distributed training.

### DIFF
--- a/tensorflow_estimator/python/estimator/training.py
+++ b/tensorflow_estimator/python/estimator/training.py
@@ -464,9 +464,9 @@ def train_and_evaluate(estimator, train_spec, eval_spec):
 
   if (config.task_type == run_config_lib.TaskType.EVALUATOR and
       config.task_id > 0):
-    raise ValueError(
-        'For distributed training, there can only be one `evaluator` task '
-        '(with task id 0).  Given task id {}'.format(config.task_id))
+    logging.info(
+        '`Evaluator` task id {} found for distributed training; normally only '
+        'task id 0 needed.'.format(config.task_id))
 
   return executor.run()
 


### PR DESCRIPTION
In my distributed training, I found that multiple evaluators can actually be supported. It is also difficult to circumvent the exception raised here outside the core estimator library.