### PR TITLE
Read all evaluation metrics from the summary file.

### DIFF
--- a/tensorflow_estimator/python/estimator/early_stopping.py
+++ b/tensorflow_estimator/python/estimator/early_stopping.py
@@ -333,7 +333,7 @@ def read_eval_metrics(eval_dir):
   Returns:
     A `dict` with global steps mapping to `dict` of metric names and values.
   """
-  eval_metrics_dict = {}
+  eval_metrics_dict = collections.defaultdict(dict)
   for event in _summaries(eval_dir):
     if not event.HasField('summary'):
       continue
@@ -342,7 +342,7 @@ def read_eval_metrics(eval_dir):
       if value.HasField('simple_value'):
         metrics[value.tag] = value.simple_value
     if metrics:
-      eval_metrics_dict[event.step] = metrics
+      eval_metrics_dict[event.step].update(metrics)
   return collections.OrderedDict(
       sorted(eval_metrics_dict.items(), key=lambda t: t[0]))
 


### PR DESCRIPTION
I would like to propose this change for reading all metrics saved in the summary file. This typically covers metrics that are computed in a `tf.train.SessionRunHook` when they are not easily expressible in terms of TensorFlow ops.