### PR TITLE
Add bazelrc and gitignore

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,5 @@
+
+# Default options should come above this line
+
+# Put user-specific options in .bazelrc.user
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
+# editor files
+*.swp
+*~
+.vscode/
+.DS_Store
+
+# bazel
 /.bazelrc.user
 /bazel-*
+
+# python
+*.pyc
+*.pyo
+__pycache__
+*.whl
+.ipynb_checkpoints


### PR DESCRIPTION
Add .bazelrc that try-import's .bazelrc.user for user-specific options.
Also add python generated and editor files to .gitignore, mainly taken
from tensorflow's gitignore.

Signed-off-by: Jason Zaman <jason@perfinion.com>