### PR TITLE
pip_package: modularize build script to allow distros to install more flexibly

### DIFF
--- a/tensorflow_estimator/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_estimator/tools/pip_package/build_pip_package.sh
@@ -23,10 +23,8 @@ function real_path() {
   is_absolute "$1" && echo "$1" || echo "$PWD/${1#./}"
 }
 
-function build_wheel() {
+function prepare_src() {
   TMPDIR="$1"
-  DEST="$2"
-  PROJECT_NAME="$3"
 
   mkdir -p "$TMPDIR"
   echo $(date) : "=== Preparing sources in dir: ${TMPDIR}"
@@ -41,6 +39,17 @@ function build_wheel() {
   # Verifies all expected files are in pip.
   # Creates init files in all directory in pip.
   python tensorflow_estimator/tools/pip_package/create_pip_helper.py --pip-root "${TMPDIR}/tensorflow_estimator/" --bazel-root "./tensorflow_estimator"
+}
+
+function build_wheel() {
+  if [ $# -lt 2 ] ; then
+    echo "No src and dest dir provided"
+    exit 1
+  fi
+
+  TMPDIR="$1"
+  DEST="$2"
+  PROJECT_NAME="$3"
 
   pushd ${TMPDIR} > /dev/null
   echo $(date) : "=== Building wheel"
@@ -49,15 +58,39 @@ function build_wheel() {
   cp dist/* ${DEST}
   popd > /dev/null
   echo $(date) : "=== Output wheel file is in: ${DEST}"
-  rm -rf "${TMPDIR}"
+}
+
+function usage() {
+  echo "Usage:"
+  echo "$0 [--src srcdir] [--dst dstdir] [options]"
+  echo "$0 dstdir [options]"
+  echo ""
+  echo "    --src                 prepare sources in srcdir"
+  echo "                              will use temporary dir if not specified"
+  echo ""
+  echo "    --dst                 build wheel in dstdir"
+  echo "                              if dstdir is not set do not build, only prepare sources"
+  echo ""
+  echo "  Options:"
+  echo "    --project_name <name> set project name to name"
+  echo "    --nightly             build tensorflow_estimator nightly"
+  echo ""
+  exit 1
 }
 
 function main() {
   NIGHTLY_BUILD=0
+  PROJECT_NAME=""
+  SRCDIR=""
+  DSTDIR=""
+  CLEANSRC=1
 
   while true; do
     if [[ -z "$1" ]]; then
       break
+    elif [[ "$1" == "--help" ]]; then
+      usage
+      exit 1
     elif [[ "$1" == "--nightly" ]]; then
       NIGHTLY_BUILD=1
     elif [[ "$1" == "--project_name" ]]; then
@@ -66,6 +99,19 @@ function main() {
         break
       fi
       PROJECT_NAME="$1"
+    elif [[ "$1" == "--src" ]]; then
+      shift
+      if [[ -z "$1" ]]; then
+        break
+      fi
+      SRCDIR="$(real_path $1)"
+      CLEANSRC=0
+    elif [[ "$1" == "--dst" ]]; then
+      shift
+      if [[ -z "$1" ]]; then
+        break
+      fi
+      DSTDIR="$(real_path $1)"
     else
       DSTDIR="$(real_path $1)"
     fi
@@ -79,16 +125,29 @@ function main() {
     fi
   fi
 
-  SRCDIR="$(mktemp -d -t tmp.XXXXXXXXXX)"
-
-  if [[ -z "$DSTDIR" ]]; then
+  if [[ -z "$DSTDIR" ]] && [[ -z "$SRCDIR" ]]; then
     echo "No destination dir provided"
+    usage
     exit 1
   fi
 
+  if [[ -z "$SRCDIR" ]]; then
+    # make temp srcdir if none set
+    SRCDIR="$(mktemp -d -t tmp.XXXXXXXXXX)"
+  fi
 
+  prepare_src "$SRCDIR"
+
+  if [[ -z "$DSTDIR" ]]; then
+      # only want to prepare sources
+      exit
+  fi
 
   build_wheel "$SRCDIR" "$DSTDIR" "$PROJECT_NAME"
+
+  if [[ $CLEANSRC -ne 0 ]]; then
+    rm -rf "${TMPDIR}"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Gentoo Linux handles python modules slightly differently and packaging
wheels is complicated. We prefer to run setup.py directly ourselves
rather than build a wheel and then install from there.

This modularizes build_pip_package.sh to allow running parts separately.
using --src srcdir will prepare the package in a known dir so the distro
package can take it from there. If only dstdir is given (either with
--dst or as the only argument to preserve backwards compat) then
behaviour is the same as before, the sources are prepared and the wheel
is built and placed in dstdir.

Signed-off-by: Jason Zaman <jason@perfinion.com>