### PR TITLE
cherry-pick build_pip_package and gitignore into r1.13 branch

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,5 @@
+
+# Default options should come above this line
+
+# Put user-specific options in .bazelrc.user
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# editor files
+*.swp
+*~
+.vscode/
+.DS_Store
+
+# bazel
+/.bazelrc.user
+/bazel-*
+
+# python
+*.pyc
+*.pyo
+__pycache__
+*.whl
+.ipynb_checkpoints

--- a/tensorflow_estimator/tools/pip_package/build_pip_package.sh
+++ b/tensorflow_estimator/tools/pip_package/build_pip_package.sh
@@ -23,10 +23,8 @@ function real_path() {
   is_absolute "$1" && echo "$1" || echo "$PWD/${1#./}"
 }
 
-function build_wheel() {
+function prepare_src() {
   TMPDIR="$1"
-  DEST="$2"
-  PROJECT_NAME="$3"
 
   mkdir -p "$TMPDIR"
   echo $(date) : "=== Preparing sources in dir: ${TMPDIR}"
@@ -67,6 +65,17 @@ function build_wheel() {
     touch "${TMPDIR}/tensorflow_estimator/contrib/estimator/python/__init__.py"
     touch "${TMPDIR}/tensorflow_estimator/contrib/estimator/python/estimator/__init__.py"
   fi
+}
+
+function build_wheel() {
+  if [ $# -lt 2 ] ; then
+    echo "No src and dest dir provided"
+    exit 1
+  fi
+
+  TMPDIR="$1"
+  DEST="$2"
+  PROJECT_NAME="$3"
 
   pushd ${TMPDIR} > /dev/null
   echo $(date) : "=== Building wheel"
@@ -75,15 +84,39 @@ function build_wheel() {
   cp dist/* ${DEST}
   popd > /dev/null
   echo $(date) : "=== Output wheel file is in: ${DEST}"
-  rm -rf "${TMPDIR}"
+}
+
+function usage() {
+  echo "Usage:"
+  echo "$0 [--src srcdir] [--dst dstdir] [options]"
+  echo "$0 dstdir [options]"
+  echo ""
+  echo "    --src                 prepare sources in srcdir"
+  echo "                              will use temporary dir if not specified"
+  echo ""
+  echo "    --dst                 build wheel in dstdir"
+  echo "                              if dstdir is not set do not build, only prepare sources"
+  echo ""
+  echo "  Options:"
+  echo "    --project_name <name> set project name to name"
+  echo "    --nightly             build tensorflow_estimator nightly"
+  echo ""
+  exit 1
 }
 
 function main() {
   NIGHTLY_BUILD=0
+  PROJECT_NAME=""
+  SRCDIR=""
+  DSTDIR=""
+  CLEANSRC=1
 
   while true; do
     if [[ -z "$1" ]]; then
       break
+    elif [[ "$1" == "--help" ]]; then
+      usage
+      exit 1
     elif [[ "$1" == "--nightly" ]]; then
       NIGHTLY_BUILD=1
     elif [[ "$1" == "--project_name" ]]; then
@@ -92,6 +125,19 @@ function main() {
         break
       fi
       PROJECT_NAME="$1"
+    elif [[ "$1" == "--src" ]]; then
+      shift
+      if [[ -z "$1" ]]; then
+        break
+      fi
+      SRCDIR="$(real_path $1)"
+      CLEANSRC=0
+    elif [[ "$1" == "--dst" ]]; then
+      shift
+      if [[ -z "$1" ]]; then
+        break
+      fi
+      DSTDIR="$(real_path $1)"
     else
       DSTDIR="$(real_path $1)"
     fi
@@ -105,16 +151,29 @@ function main() {
     fi
   fi
 
-  SRCDIR="$(mktemp -d -t tmp.XXXXXXXXXX)"
-
-  if [[ -z "$DSTDIR" ]]; then
+  if [[ -z "$DSTDIR" ]] && [[ -z "$SRCDIR" ]]; then
     echo "No destination dir provided"
+    usage
     exit 1
   fi
 
+  if [[ -z "$SRCDIR" ]]; then
+    # make temp srcdir if none set
+    SRCDIR="$(mktemp -d -t tmp.XXXXXXXXXX)"
+  fi
 
+  prepare_src "$SRCDIR"
+
+  if [[ -z "$DSTDIR" ]]; then
+      # only want to prepare sources
+      exit
+  fi
 
   build_wheel "$SRCDIR" "$DSTDIR" "$PROJECT_NAME"
+
+  if [[ $CLEANSRC -ne 0 ]]; then
+    rm -rf "${TMPDIR}"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
This cherry-picks https://github.com/tensorflow/estimator/pull/24 and https://github.com/tensorflow/estimator/pull/25 into the r1.13 release branch.

The pip_package script has changed between r1.13 and master so that patch is slightly different. .bazelrc and .gitignore were missing completely so those files were just added.