### PR TITLE
Fix/import from keras.utils.metric_utils.py

### DIFF
--- a/tensorflow_estimator/python/estimator/head/binary_class_head.py
+++ b/tensorflow_estimator/python/estimator/head/binary_class_head.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from tensorflow.python.eager import context
 from tensorflow.python.framework import ops
 from tensorflow.python.keras import metrics
-from tensorflow.python.keras.utils import metrics_utils
+from tensorflow.python.keras.utils.metrics_utils import AUCCurve
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import lookup_ops
@@ -312,7 +312,7 @@ class BinaryClassHead(base_head.Head):
       # The default summation_method is "interpolation" in the AUC metric.
       eval_metrics[self._auc_key] = metrics.AUC(name=keys.AUC)
       eval_metrics[self._auc_pr_key] = metrics.AUC(
-          curve=metrics_utils.AUCCurve.PR, name=keys.AUC_PR)
+          curve=AUCCurve.PR, name=keys.AUC_PR)
       if regularization_losses is not None:
         eval_metrics[self._loss_regularization_key] = metrics.Mean(
             name=keys.LOSS_REGULARIZATION)


### PR DESCRIPTION
Currently I'm experiencing following problem: 
```
File "/anaconda2/envs/research36/lib/python3.6/site-packages/tensorflow_estimator/python/estimator/head/binary_class_head.py", line 24, in <module>
    from tensorflow.python.keras.utils import metrics_utils
ImportError: cannot import name 'metrics_utils'
```

This PR together with https://github.com/tensorflow/tensorflow/pull/25529