### PR TITLE
Fix configure of CollectiveAllReduceStrategy in Estimator.

### DIFF
--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -1208,7 +1208,11 @@ class Estimator(object):
           hooks)
       return self
     else:
-      self._config._train_distribute.configure(self._config.session_config)
+      self._config._train_distribute.configure(
+          self._config.session_config,
+          cluster_spec = self._config.cluster_spec,
+          task_type = self._config.task_type,
+          task_id = self._config.task_id)
       return self._actual_train_model_distributed(
           self._config._train_distribute, input_fn, hooks, saving_listeners)
     # pylint: enable=protected-access


### PR DESCRIPTION
If I use `CollectiveAllReduceStrategy` in TF 1.13 or `MultiWorkerMirroredStrategy` in TF2.0alpha0 with `Estimator`, it would place many tensors onto the chief node, which causes OOM of chief node. This can be fixed by pass cluster_spec and task information to distribution strategy in its `configure`.