### PR TITLE
Fixed 4 issues of type: PYTHON_E225 throughout 3 files in repo.

### DIFF
--- a/tensorflow_estimator/contrib/estimator/python/estimator/head_test.py
+++ b/tensorflow_estimator/contrib/estimator/python/estimator/head_test.py
@@ -88,7 +88,7 @@ def _sigmoid_cross_entropy(labels, logits):
   sigmoid_logits = _sigmoid(logits)
   unreduced_result = (
       -labels * np.log(sigmoid_logits)
-      -(1 - labels) * np.log(1 - sigmoid_logits))
+      - (1 - labels) * np.log(1 - sigmoid_logits))
   # Mean over classes
   return np.mean(unreduced_result, axis=-1, keepdims=True)
 

--- a/tensorflow_estimator/python/estimator/head/multi_label_head_test.py
+++ b/tensorflow_estimator/python/estimator/head/multi_label_head_test.py
@@ -51,7 +51,7 @@ def _sigmoid_cross_entropy(labels, logits):
   sigmoid_logits = 1 / (1 + np.exp(-logits))
   unreduced_result = (
       -labels * np.log(sigmoid_logits)
-      -(1 - labels) * np.log(1 - sigmoid_logits))
+      - (1 - labels) * np.log(1 - sigmoid_logits))
   # Mean over classes
   return np.mean(unreduced_result, axis=-1, keepdims=True)
 

--- a/tensorflow_estimator/python/estimator/training_test.py
+++ b/tensorflow_estimator/python/estimator/training_test.py
@@ -983,7 +983,7 @@ class TrainingExecutorRunMasterTest(test.TestCase):
         input_fn=lambda: 1, steps=2, exporters=exporter, throttle_secs=10)
 
     mock_est.evaluate.side_effect = [
-        {_GLOBAL_STEP_KEY: train_spec.max_steps //2},
+        {_GLOBAL_STEP_KEY: train_spec.max_steps // 2},
         {_GLOBAL_STEP_KEY: train_spec.max_steps}
     ]
 
@@ -1036,7 +1036,7 @@ class TrainingExecutorRunMasterTest(test.TestCase):
         input_fn=lambda: 1, steps=2, exporters=exporter, throttle_secs=10)
 
     mock_est.evaluate.side_effect = [
-        {_GLOBAL_STEP_KEY: train_spec.max_steps //2},
+        {_GLOBAL_STEP_KEY: train_spec.max_steps // 2},
         {_GLOBAL_STEP_KEY: train_spec.max_steps}
     ]
 


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.