### PR TITLE
Add alternative protocols supported by TF and SIG-Networking

### DIFF
--- a/tensorflow_estimator/python/estimator/run_config.py
+++ b/tensorflow_estimator/python/estimator/run_config.py
@@ -311,8 +311,9 @@ def _validate_properties(run_config):
                     ' one argument "op".')
 
   _validate('protocol',
-            lambda protocol: protocol in (None, "grpc", "grpc+verbs"),
-            message='protocol should be grpc or grpc+verbs')
+            lambda protocol: protocol in (
+                None, "grpc", "grpc+verbs", "grpc+gdr", "grpc+mpi", "grpc+seastar"),
+            message='protocol should be either grpc, grpc+verbs, grpc+gdr, grpc+mpi, or grpc+seastar')
 
 
 def get_default_session_config():


### PR DESCRIPTION
Right now TF 1.x supports the following networking protocols:

* grpc: default
* grpc+verbs: https://github.com/tensorflow/tensorflow/pull/8943
* grpc+mpi: https://github.com/tensorflow/tensorflow/pull/9864
* grpc+gdr: https://github.com/tensorflow/tensorflow/pull/11392
* grpc+seastar (PR pending): https://github.com/tensorflow/tensorflow/pull/30168

And once we reach 2.0, these protocols will be supported by [SIG-Networking](https://github.com/tensorflow/networking).