### PR TITLE
Deleted outdated TPUEstimator documentation

### DIFF
--- a/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
@@ -2622,7 +2622,7 @@ class TPUEstimator(estimator_lib.Estimator):
         including 'batch_size'.
       use_tpu: A bool indicating whether TPU support is enabled. Currently, -
         TPU training and evaluation respect this bit, but eval_on_tpu can
-        override execution of eval. See below. - Predict still happens on CPU.
+        override execution of eval. See below.
       train_batch_size: An int representing the global training batch size.
         TPUEstimator transforms this global batch size to a per-shard batch
         size, as params['batch_size'], when calling `input_fn` and `model_fn`.


### PR DESCRIPTION
In the TPUEstimator documentation at <a href="https://github.com/tensorflow/estimator/blob/cb31601f2875183ed04c13bb158631f8c67fbdad/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py#L2623-2625">tpu_estimator.py#L2623-2625</a> is outdated as according to <a href="https://github.com/tensorflow/estimator/blob/cb31601f2875183ed04c13bb158631f8c67fbdad/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py#L2441-2462">tpu_estimator.py#L2441-2462</a>, predicting using TPU's now works, so the line where it says "- Predict still happens on CPU" should be removed.