### PR TITLE
Update InMemoryEvaluatorHook to use init_op

### DIFF
--- a/tensorflow_estimator/python/estimator/hooks/hooks.py
+++ b/tensorflow_estimator/python/estimator/hooks/hooks.py
@@ -186,12 +186,10 @@ class InMemoryEvaluatorHook(training.SessionRunHook):
         for v_name in var_name_to_value
     }
 
-    def feed_variables(scaffold, session):
-      del scaffold
-      session.run(self._var_feed_op, feed_dict=placeholder_to_value)
-
     scaffold = training.Scaffold(
-        init_fn=feed_variables, copy_from_scaffold=self._scaffold)
+        init_op=self._var_feed_op,
+        init_feed_dict=placeholder_to_value,
+        copy_from_scaffold=self._scaffold)
 
     with self._graph.as_default():
       self._estimator._evaluate_run(


### PR DESCRIPTION
An attempt to resolve this TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/30807

Testing with this change, it seems that while the memory footprint is still very large, it does not continuously grow.

I'm not entirely sure why this works, but my logic was stemming from these lines:

https://github.com/tensorflow/tensorflow/blob/5e2a91f65cfb23f996136b9201d9312c9c36b941/tensorflow/python/training/monitored_session.py#L184-L194

Which it seems we would not like to call repeatedly

I'm not sure if deleting the scaffold inside `init_fn` is necessary, if so we can add it back in addition to this change.