### PR TITLE
Fixes the bug that the first export was ignored by BestExporter 

### DIFF
--- a/tensorflow_estimator/python/estimator/exporter.py
+++ b/tensorflow_estimator/python/estimator/exporter.py
@@ -268,6 +268,7 @@ class BestExporter(Exporter):
     self._event_file_pattern = event_file_pattern
     self._model_dir = None
     self._best_eval_result = None
+    self._has_exported = False
 
     self._exports_to_keep = exports_to_keep
     if exports_to_keep is not None and exports_to_keep <= 0:
@@ -293,15 +294,20 @@ class BestExporter(Exporter):
       self._best_eval_result = self._get_best_eval_result(
           full_event_file_pattern)
 
-    if self._best_eval_result is None or self._compare_fn(
-        best_eval_result=self._best_eval_result,
-        current_eval_result=eval_result):
+    if (self._best_eval_result is None or
+        # check if this is the first export. Note that
+        # evaluation occurs before exporting models and hence the loaded
+        # _best_eval_result can be the same even when no export had been done.
+        (not self._has_exported and self._best_eval_result == eval_result) or
+        self._compare_fn(best_eval_result=self._best_eval_result,
+        current_eval_result=eval_result)):
       tf_logging.info('Performing best model export.')
       self._best_eval_result = eval_result
       export_result = self._saved_model_exporter.export(
           estimator, export_path, checkpoint_path, eval_result,
           is_the_final_export)
       self._garbage_collect_exports(export_path)
+      self._has_exported = True
 
     return export_result
 


### PR DESCRIPTION
At `_TrainingExecutor._Evaluator.evaluate_and_export()`, first a model is evaluated and then exported. That means for the first import, the same `eval_result` will be loaded in `self._best_eval_result` and therefore, the first model will be ignored in BestExporter. This can be fixed in three ways:
1. Modify `_compare_fn` such that it returns true when two results are equal. This solution is not efficient because the export will always happen when `eval_result` is equal to `_best_eval_result`. Also, it may change the exported models in third party code. 
2. Change the logic in `evaluate_and_export()` and export before storing evaluation results. I am not sure about the side-effect of this solution and its implementation may be complex.
3. Add logics to `BestExporter` to guarantee an export for the first model. This solution has been picked for this PR.

This bug has been reported in #35. In this PR, I have addressed the comments in #35 as well.