### PR TITLE
Fix broken release

### DIFF
--- a/tensorflow_estimator/python/estimator/tpu/tpu_context.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_context.py
@@ -795,18 +795,19 @@ class _TPUEstimatorReplicaContext(distribute_lib.ReplicaContext):
     # pylint: enable=protected-access
 
   def __enter__(self):
+    ctx = eager_context.context()
+
     def replica_id_is_zero():
       return math_ops.equal(self._replica_id_in_sync_group,
                             constant_op.constant(0))
 
-    summary_state = summary_ops_v2._summary_state  # pylint: disable=protected-access
     self._summary_recording_distribution_strategy = (
-        summary_state.is_recording_distribution_strategy)
-    summary_state.is_recording_distribution_strategy = replica_id_is_zero
+        ctx.summary_recording_distribution_strategy)
+    ctx.summary_recording_distribution_strategy = replica_id_is_zero
 
   def __exit__(self, exception_type, exception_value, traceback):
-    summary_state = summary_ops_v2._summary_state  # pylint: disable=protected-access
-    summary_state.is_recording_distribution_strategy = (
+    ctx = eager_context.context()
+    ctx.summary_recording_distribution_strategy = (
         self._summary_recording_distribution_strategy)
 
 

--- a/tensorflow_estimator/tools/pip_package/setup.py
+++ b/tensorflow_estimator/tools/pip_package/setup.py
@@ -30,7 +30,7 @@ DOCLINES = __doc__.split('\n')
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
-_VERSION = '2.0.0'
+_VERSION = '2.0.1'
 
 REQUIRED_PACKAGES = [
     # We depend on TensorFlow's declared pip dependencies.


### PR DESCRIPTION
TensorFlow Estimator 2.0 has been released with a private import of a symbol from TensorFlow master. However, that symbol does not exist on TensorFlow 2.0, due to a race condition regarding branch cuts.

This PR fixes usages of this symbol.

Googlers: b/142956047