### PR TITLE
Implement the logic in tpu estimator to support user provided stopping signals and save a checkpoint before stop.

### DIFF
--- a/tensorflow_estimator/python/estimator/tpu/tpu_config.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_config.py
@@ -57,6 +57,7 @@ class TPUConfig(
         'eval_training_input_configuration',
         'experimental_host_call_every_n_steps',
         'experimental_allow_per_host_v2_parallel_get_next',
+        'experimental_user_provided_stopping_signals_name',
     ])):
   r"""TPU related configuration required by `TPUEstimator`.
 
@@ -128,6 +129,28 @@ class TPUConfig(
       time, but as a consequence TPUEstimator may non-deterministically
       distribute batches to different cores, rather than guaranteeing round
       robin behavior.
+    experimental_user_provided_stopping_signals_name: If not None, it is the
+      user provided stopping signals name. User can then write a map_fn to add
+      stopping signals with experimental_user_provided_stopping_signals_name as
+      name in their input dataset. Example is as following:
+      def insert_stopping_signal(stop, batch_size):
+        def _map_fn(features):
+          shape = [batch_size, 1]
+          dtype = tf.dtypes.bool
+          if stop is True:
+            features[experimental_user_provided_stopping_signals_name] \
+              = tf.ones(shape=shape, dtype=dtype)
+          else:
+            features[experimental_user_provided_stopping_signals_name] \
+              = tf.zeros(shape=shape, dtype=dtype)
+          return features
+        return _map_fn
+
+      # Insert stop signal which is True.
+      dataset_0 = dataset.map(insert_stopping_signal(stop=True, batch_size=128))
+
+      # Insert stop signal which is False.
+      dataset_1 = dataset.map(insert_stopping_signal(stop=False, batch_size=128))
 
   Raises:
       ValueError: If `num_cores_per_replica` is not 1, 2, 4, 8, ..., 128.
@@ -143,7 +166,8 @@ class TPUConfig(
               input_partition_dims=None,
               eval_training_input_configuration=InputPipelineConfig.PER_HOST_V1,
               experimental_host_call_every_n_steps=1,
-              experimental_allow_per_host_v2_parallel_get_next=False):
+              experimental_allow_per_host_v2_parallel_get_next=False,
+              experimental_user_provided_stopping_signals_name=None):
 
     # Check iterations_per_loop.
     util_lib.parse_iterations_per_loop(iterations_per_loop)
@@ -207,7 +231,9 @@ class TPUConfig(
         experimental_host_call_every_n_steps=(
             experimental_host_call_every_n_steps),
         experimental_allow_per_host_v2_parallel_get_next=(
-            experimental_allow_per_host_v2_parallel_get_next)
+            experimental_allow_per_host_v2_parallel_get_next),
+        experimental_user_provided_stopping_signals_name=(
+          experimental_user_provided_stopping_signals_name),
     )
 
 

--- a/tensorflow_estimator/python/estimator/tpu/tpu_config.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_config.py
@@ -57,7 +57,7 @@ class TPUConfig(
         'eval_training_input_configuration',
         'experimental_host_call_every_n_steps',
         'experimental_allow_per_host_v2_parallel_get_next',
-        'experimental_user_provided_stopping_signals_name',
+        'experimental_customized_tpu_infeed_outfeed_session_hook_class',
     ])):
   r"""TPU related configuration required by `TPUEstimator`.
 
@@ -129,28 +129,13 @@ class TPUConfig(
       time, but as a consequence TPUEstimator may non-deterministically
       distribute batches to different cores, rather than guaranteeing round
       robin behavior.
-    experimental_user_provided_stopping_signals_name: If not None, it is the
-      user provided stopping signals name. User can then write a map_fn to add
-      stopping signals with experimental_user_provided_stopping_signals_name as
-      name in their input dataset. Example is as following:
-      def insert_stopping_signal(stop, batch_size):
-        def _map_fn(features):
-          shape = [batch_size, 1]
-          dtype = tf.dtypes.bool
-          if stop is True:
-            features[experimental_user_provided_stopping_signals_name] \
-              = tf.ones(shape=shape, dtype=dtype)
-          else:
-            features[experimental_user_provided_stopping_signals_name] \
-              = tf.zeros(shape=shape, dtype=dtype)
-          return features
-        return _map_fn
-
-      # Insert stop signal which is True.
-      dataset_0 = dataset.map(insert_stopping_signal(stop=True, batch_size=128))
-
-      # Insert stop signal which is False.
-      dataset_1 = dataset.map(insert_stopping_signal(stop=False, batch_size=128))
+    experimental_customized_tpu_infeed_outfeed_session_hook_class: This is a class
+      which user can provide to the TPU estimator to override the default 
+      TPUInfeedOutfeedSessionHook implementation and add customized implementatioin
+      to handle infeed outfeed logic. If given class is None, TPU estimator uses default 
+      TPUInfeedOutfeedSessionHook implementation in tpu_estimator.py. If not None, 
+      TPU estimator uses this customized tpu infeed outfeed session hook class rather
+      to override the default one.
 
   Raises:
       ValueError: If `num_cores_per_replica` is not 1, 2, 4, 8, ..., 128.
@@ -167,7 +152,7 @@ class TPUConfig(
               eval_training_input_configuration=InputPipelineConfig.PER_HOST_V1,
               experimental_host_call_every_n_steps=1,
               experimental_allow_per_host_v2_parallel_get_next=False,
-              experimental_user_provided_stopping_signals_name=None):
+              experimental_customized_tpu_infeed_outfeed_session_hook_class=None):
 
     # Check iterations_per_loop.
     util_lib.parse_iterations_per_loop(iterations_per_loop)
@@ -232,8 +217,8 @@ class TPUConfig(
             experimental_host_call_every_n_steps),
         experimental_allow_per_host_v2_parallel_get_next=(
             experimental_allow_per_host_v2_parallel_get_next),
-        experimental_user_provided_stopping_signals_name=(
-          experimental_user_provided_stopping_signals_name),
+        experimental_customized_tpu_infeed_outfeed_session_hook_class=(
+            experimental_customized_tpu_infeed_outfeed_session_hook_class)
     )
 
 

--- a/tensorflow_estimator/python/estimator/tpu/tpu_config.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_config.py
@@ -57,7 +57,7 @@ class TPUConfig(
         'eval_training_input_configuration',
         'experimental_host_call_every_n_steps',
         'experimental_allow_per_host_v2_parallel_get_next',
-        'experimental_customized_tpu_infeed_outfeed_session_hook_class',
+        'experimental_feed_hook',
     ])):
   r"""TPU related configuration required by `TPUEstimator`.
 
@@ -129,13 +129,13 @@ class TPUConfig(
       time, but as a consequence TPUEstimator may non-deterministically
       distribute batches to different cores, rather than guaranteeing round
       robin behavior.
-    experimental_customized_tpu_infeed_outfeed_session_hook_class: This is a class
-      which user can provide to the TPU estimator to override the default 
-      TPUInfeedOutfeedSessionHook implementation and add customized implementatioin
-      to handle infeed outfeed logic. If given class is None, TPU estimator uses default 
-      TPUInfeedOutfeedSessionHook implementation in tpu_estimator.py. If not None, 
-      TPU estimator uses this customized tpu infeed outfeed session hook class rather
-      to override the default one.
+    experimental_feed_hook: This is a class which user can provide to the TPU
+      estimator to override the default TPUInfeedOutfeedSessionHook implementation
+      and add customized implementatioin to handle infeed outfeed logic. If
+      given class is None, TPU estimator uses default TPUInfeedOutfeedSessionHook
+      implementation in tpu_estimator.py. If not None, TPU estimator uses this
+      customized tpu infeed outfeed session hook class rather to override the
+      default one.
 
   Raises:
       ValueError: If `num_cores_per_replica` is not 1, 2, 4, 8, ..., 128.
@@ -152,7 +152,7 @@ class TPUConfig(
               eval_training_input_configuration=InputPipelineConfig.PER_HOST_V1,
               experimental_host_call_every_n_steps=1,
               experimental_allow_per_host_v2_parallel_get_next=False,
-              experimental_customized_tpu_infeed_outfeed_session_hook_class=None):
+              experimental_feed_hook=None):
 
     # Check iterations_per_loop.
     util_lib.parse_iterations_per_loop(iterations_per_loop)
@@ -217,8 +217,8 @@ class TPUConfig(
             experimental_host_call_every_n_steps),
         experimental_allow_per_host_v2_parallel_get_next=(
             experimental_allow_per_host_v2_parallel_get_next),
-        experimental_customized_tpu_infeed_outfeed_session_hook_class=(
-            experimental_customized_tpu_infeed_outfeed_session_hook_class)
+        experimental_feed_hook=(
+            experimental_feed_hook)
     )
 
 

--- a/tensorflow_estimator/python/estimator/tpu/tpu_context.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_context.py
@@ -403,9 +403,9 @@ class _InternalTPUContext(object):
             .experimental_allow_per_host_v2_parallel_get_next)
 
   @property
-  def customized_tpu_infeed_outfeed_session_hook_class(self):
+  def feed_hook(self):
     return (self._config.tpu_config
-            .experimental_customized_tpu_infeed_outfeed_session_hook_class)
+            .experimental_feed_hook)
 
   @property
   def model_parallelism_enabled(self):

--- a/tensorflow_estimator/python/estimator/tpu/tpu_context.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_context.py
@@ -403,9 +403,9 @@ class _InternalTPUContext(object):
             .experimental_allow_per_host_v2_parallel_get_next)
 
   @property
-  def user_provided_stopping_signals_name(self):
+  def customized_tpu_infeed_outfeed_session_hook_class(self):
     return (self._config.tpu_config
-            .experimental_user_provided_stopping_signals_name)
+            .experimental_customized_tpu_infeed_outfeed_session_hook_class)
 
   @property
   def model_parallelism_enabled(self):

--- a/tensorflow_estimator/python/estimator/tpu/tpu_context.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_context.py
@@ -403,6 +403,11 @@ class _InternalTPUContext(object):
             .experimental_allow_per_host_v2_parallel_get_next)
 
   @property
+  def user_provided_stopping_signals_name(self):
+    return (self._config.tpu_config
+            .experimental_user_provided_stopping_signals_name)
+
+  @property
   def model_parallelism_enabled(self):
     return self._model_parallelism_enabled
 

--- a/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
@@ -1815,9 +1815,9 @@ class _ModelFnWrapper(object):
 
       stopping_signals = None
       user_provided_stopping_signals_name = None
-      if self._ctx.customized_tpu_infeed_outfeed_session_hook_class is not None:
+      if self._ctx.feed_hook is not None:
         stopping_signals, user_provided_stopping_signals_name = \
-          self._ctx.customized_tpu_infeed_outfeed_session_hook_class.get_stopping_signals_and_name(features)
+          self._ctx.feed_hook.get_stopping_signals_and_name(features)
 
       # We must run train_op to update the variables prior to running the
       # outfeed.
@@ -3304,9 +3304,9 @@ class TPUEstimator(estimator_lib.Estimator):
             global_step = tf.identity(tf.compat.v1.train.get_global_step())
           hooks = input_hooks + shutdown_hooks
 
-          if ctx.customized_tpu_infeed_outfeed_session_hook_class is not None:
+          if ctx.feed_hook is not None:
             tf.compat.v1.logging.info('Use user implemented tpu infeed outfeed session hook class.')
-            infeed_outfeed_session_hook_class = ctx.customized_tpu_infeed_outfeed_session_hook_class
+            infeed_outfeed_session_hook_class = ctx.feed_hook
           else:
             infeed_outfeed_session_hook_class = TPUInfeedOutfeedSessionHook
 

--- a/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
+++ b/tensorflow_estimator/python/estimator/tpu/tpu_estimator.py
@@ -510,9 +510,6 @@ class TPUInfeedOutfeedSessionHook(tf.compat.v1.train.SessionRunHook):
       self._should_initialize_tpu = True
     self._outfeed_every_n_steps = outfeed_every_n_steps
 
-    self.user_provided_stopping_signals_name = ctx.user_provided_stopping_signals_name
-    self.stopping_signal = False
-
   def begin(self):
     tf.compat.v1.logging.info('TPU job name %s', self._master_job)
     self._iterations_per_loop_var = _create_or_get_iterations_per_loop()
@@ -554,27 +551,15 @@ class TPUInfeedOutfeedSessionHook(tf.compat.v1.train.SessionRunHook):
     tf.compat.v1.logging.info('Starting outfeed thread controller.')
     status_logger = PeriodicLogger(seconds=60)
     with self._rendezvous.catch_errors(source='outfeed', session=session):
-      stopping_signals = False
       for count, steps in enumerate(queue_ctx.read_iteration_counts()):
         step_counter = 0
         for i in xrange(steps):
           tf.compat.v1.logging.debug('Outfeed dequeue for iteration (%d, %d)',
                                      count, i)
           if step_counter % self._outfeed_every_n_steps == 0:
-            ret = session.run(self._dequeue_ops)
-            if self.user_provided_stopping_signals_name is not None \
-              and self.user_provided_stopping_signals_name in ret:
-              if 'stopping' not in ret[self.user_provided_stopping_signals_name]:
-                raise RuntimeError('ret[{}] must contain key \'stopping\'.').format(self.user_provided_stopping_signals_name)
-              if ret[self.user_provided_stopping_signals_name]['stopping'][0] == True \
-                and stopping_signals == False:
-                stopping_signals = True
-                tf.compat.v1.logging.info('Encountered stop signal at iteration (%d, %d).', count, i)
+            session.run(self._dequeue_ops)
           step_counter += 1
           status_logger.log('Outfeed finished for iteration (%d, %d)', count, i)
-        if stopping_signals == True:
-          tf.compat.v1.logging.info('Set shared stop signal at iteration (%d, %d).', count, i)
-          self.stopping_signal = True
       tf.compat.v1.logging.info('Outfeed thread finished, shutting down.')
 
   def _create_infeed_controller(self, name, target, args):
@@ -626,10 +611,6 @@ class TPUInfeedOutfeedSessionHook(tf.compat.v1.train.SessionRunHook):
           session, shutdown_timeout=watchdog_timeout)
 
   def before_run(self, run_context):
-    if self.stopping_signal == True:
-      tf.compat.v1.logging.info('Throw OutOfRangeError error due to encountering stopping signal in before_run.')
-      raise tf.errors.OutOfRangeError(None, None, 'Stopped by stopping signal.')
-
     iterations = run_context.session.run(self._iterations_per_loop_var)
 
     tf.compat.v1.logging.info('Enqueue next (%d) batch(es) of data to infeed.',
@@ -1833,11 +1814,10 @@ class _ModelFnWrapper(object):
         ]
 
       stopping_signals = None
-      if self._ctx.user_provided_stopping_signals_name is not None \
-          and self._ctx.user_provided_stopping_signals_name in features:
-        sum_stopping_signals = tf.compat.v1.tpu.cross_replica_sum(
-          tf.cast(features[self._ctx.user_provided_stopping_signals_name], tf.int32))
-        stopping_signals = {'stopping': sum_stopping_signals > 0}
+      user_provided_stopping_signals_name = None
+      if self._ctx.customized_tpu_infeed_outfeed_session_hook_class is not None:
+        stopping_signals, user_provided_stopping_signals_name = \
+          self._ctx.customized_tpu_infeed_outfeed_session_hook_class.get_stopping_signals_and_name(features)
 
       # We must run train_op to update the variables prior to running the
       # outfeed.
@@ -1851,7 +1831,7 @@ class _ModelFnWrapper(object):
 
         if stopping_signals is not None:
           identity_fn = lambda **kwargs: kwargs
-          tracer_host_call[self._ctx.user_provided_stopping_signals_name] = [identity_fn, stopping_signals]
+          tracer_host_call[user_provided_stopping_signals_name] = [identity_fn, stopping_signals]
 
         if host_call_fn:
           # Ignore dummy hostcalls (no arguments)
@@ -3323,8 +3303,15 @@ class TPUEstimator(estimator_lib.Estimator):
           with tf.control_dependencies([loss]):
             global_step = tf.identity(tf.compat.v1.train.get_global_step())
           hooks = input_hooks + shutdown_hooks
+
+          if ctx.customized_tpu_infeed_outfeed_session_hook_class is not None:
+            tf.compat.v1.logging.info('Use user implemented tpu infeed outfeed session hook class.')
+            infeed_outfeed_session_hook_class = ctx.customized_tpu_infeed_outfeed_session_hook_class
+          else:
+            infeed_outfeed_session_hook_class = TPUInfeedOutfeedSessionHook
+
           hooks.extend([
-              TPUInfeedOutfeedSessionHook(
+              infeed_outfeed_session_hook_class(
                   ctx,
                   enqueue_ops,
                   host_ops,


### PR DESCRIPTION
Implement the logic in tpu estimator to support user provided
True/False stopping signals in the input data. When tpu estimator
encounters the user provided stopping signals with True value, it will save a
checkpoint automatically after finishing current iteration_per_loop and stops the
training. For users to use this feature, they will need add stopping signals with False
value in their real input data. And they will add some enough empty data after real input
data in the end which they know how to handle in their model code and have stopping 
signals with True value.