### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Estimators encapsulate training, evaluation, prediction, and exporting for your 
 
 ## Getting Started
 
-See our Estimator [getting started guide](https://www.tensorflow.org/guide/estimators) for an introduction to the Estimator APIs.
+See our Estimator [getting started guide](https://www.tensorflow.org/guide/estimator) for an introduction to the Estimator APIs.
 
 ## Installation
 
-`tf.estimator` is installed when you install the TensorFlow pip package. See [Installing TensorFlow](https://www.tensorflow.org/get_started/os_setup.html) for instructions.
+`tf.estimator` is installed when you install the TensorFlow pip package. See [Installing TensorFlow](https://www.tensorflow.org/install) for instructions.
 
 ## Developing
 


### PR DESCRIPTION
Updated broken links for

- Estimator getting started guide and
- TensorFlow 2 installation guide

Fixes issue [#47494](https://github.com/tensorflow/tensorflow/issues/47494) in tensorflow/tensorflow repo. 