### PR TITLE
Enable tracing in estimator training

### DIFF
--- a/tensorflow_estimator/python/estimator/BUILD
+++ b/tensorflow_estimator/python/estimator/BUILD
@@ -941,6 +941,7 @@ py_test(
     srcs_version = "PY3",
     tags = ["notsan"],  # b/67510291
     deps = [
+        ":estimator_py",
         ":estimator",
         ":export",
         ":mode_keys",

--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -33,6 +33,7 @@ from tensorflow.python.eager import context
 from tensorflow.python.eager import monitoring
 from tensorflow.python.framework import ops
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.profiler import trace
 from tensorflow.python.saved_model import utils_impl as saved_model_utils
 from tensorflow.python.summary import summary
 from tensorflow.python.training import basic_session_run_hooks
@@ -1354,6 +1355,7 @@ class Estimator(object):
     if saving_listener:
       raise ValueError('Saving listenor is not supported by the current '
                        'Distribution Strategies.')
+    #TODO: consolidate code duplication in _train_with_estimator_spec 
     with training.MonitoredTrainingSession(
         master=self._config.master,
         is_chief=self._config.is_chief,
@@ -1369,13 +1371,16 @@ class Estimator(object):
         log_step_count_steps=self._config.log_step_count_steps,
         save_graph_def=self._config.checkpoint_save_graph_def) as mon_sess:
       loss = None
-      any_step_done = False
+      current_step = 0
       while not mon_sess.should_stop():
-        _, loss = mon_sess.run([estimator_spec.train_op, estimator_spec.loss])
-        any_step_done = True
-    if not any_step_done:
-      tf.compat.v1.logging.warn('Training with estimator made no steps. '
-                                'Perhaps input is empty or misspecified.')
+        current_step = current_step+1
+        # just as keras(https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/engine/training.py#L1093),
+        # trace should be enabled for every step
+        with trace.Trace('train', step_num=current_step, _r=1):
+          _, loss = mon_sess.run([estimator_spec.train_op, estimator_spec.loss])
+      if current_step == 0:
+        tf.compat.v1.logging.warn('Training with estimator made no steps. '
+                                  'Perhaps input is empty or misspecified.')
     return loss
 
   def _train_with_estimator_spec(self, estimator_spec, worker_hooks, hooks,
@@ -1509,13 +1514,16 @@ class Estimator(object):
         log_step_count_steps=log_step_count_steps,
         save_graph_def=self._config.checkpoint_save_graph_def) as mon_sess:
       loss = None
-      any_step_done = False
+      current_step = 0
       while not mon_sess.should_stop():
-        _, loss = mon_sess.run([estimator_spec.train_op, estimator_spec.loss])
-        any_step_done = True
-    if not any_step_done:
-      tf.compat.v1.logging.warn('Training with estimator made no steps. '
-                                'Perhaps input is empty or misspecified.')
+        current_step = current_step+1
+        # just as keras(https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/engine/training.py#L1093),
+        # trace should be enabled for every step
+        with trace.Trace('train', step_num=current_step, _r=1):
+          _, loss = mon_sess.run([estimator_spec.train_op, estimator_spec.loss])
+      if current_step == 0:
+        tf.compat.v1.logging.warn('Training with estimator made no steps. '
+                                  'Perhaps input is empty or misspecified.')
     return loss
 
   def _evaluate_build_graph(self, input_fn, hooks=None, checkpoint_path=None):

--- a/tensorflow_estimator/python/estimator/estimator.py
+++ b/tensorflow_estimator/python/estimator/estimator.py
@@ -1373,7 +1373,7 @@ class Estimator(object):
       loss = None
       current_step = 0
       while not mon_sess.should_stop():
-        current_step = current_step+1
+        current_step += 1 
         # just as keras(https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/engine/training.py#L1093),
         # trace should be enabled for every step
         with trace.Trace('train', step_num=current_step, _r=1):
@@ -1516,7 +1516,7 @@ class Estimator(object):
       loss = None
       current_step = 0
       while not mon_sess.should_stop():
-        current_step = current_step+1
+        current_step += 1
         # just as keras(https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/engine/training.py#L1093),
         # trace should be enabled for every step
         with trace.Trace('train', step_num=current_step, _r=1):


### PR DESCRIPTION
This PR enables [tracing](https://www.tensorflow.org/api_docs/python/tf/profiler/experimental/Trace) in estimator when **training** so that [TF profiler](https://www.tensorflow.org/guide/profiler) is able to work with estimator properly(Related issue: https://github.com/tensorflow/profiler/issues/84). This echos the [behavior of keras](https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/engine/training.py#L1093) which enables tracing by default. 

Note that based on the [TF tracing impl](https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/core/profiler/lib/traceme.h#L139), this change **won't incur performance overhead** when profiler is off as
1. If tracer is on but the profiler is off, TF _won’t_ actually trace anything.
2. Tracer will start tracing only after profiler starts. As a result, it _would trace the profiling steps only_.

